### PR TITLE
Parse linkchecker output for 400s

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -1,5 +1,4 @@
 name: docs links on maas.io/docs
-
 on:
   schedule:
     - cron: "0 13 * * *"
@@ -7,41 +6,27 @@ on:
 
 jobs:
   check-links:
-    if: github.repository == 'canonical-web-and-design/maas.io'
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Install linkchecker
         run: sudo pip install LinkChecker
 
       - name: Write linkchecker config file
         run: |
           mkdir -p ~/.linkchecker
-          cat > ~/.linkchecker/linkcheckerrc <<EOF
-          [checking]
-          maxrequestspersecond=5
-          
-          [filtering]
-          nofollow=!https:\/\/maas.io\/docs\/
-          checkextern=1
-          ignore=
-            https://res\.cloudinary\.com
-            .*&start=
-            /q_auto
-            /fl_sanitize
-            /w_
-            /h_
-            https://assets\.ubuntu\.com
-            https?://.*example\.com
-            https://my\.registry:port
-          
-          [output]
-          status=0
-          warnings=0
-          EOF
+          cp scripts/linkcheckerrc ~/.linkchecker/
+
       - name: Run linkchecker
+        continue-on-error: true
         run: |
-          linkchecker https://maas.io/docs
+          linkchecker https://maas.io/docs > ~/.linkchecker/linkchecker-out.txt
+
+      - name: Parse linkchecker output
+        run: |
+          scripts/runDocsLinkchecker
 
       - name: Send message on failure
         if: failure()

--- a/scripts/linkcheckerrc
+++ b/scripts/linkcheckerrc
@@ -1,0 +1,20 @@
+[checking]
+maxrequestspersecond=5
+
+[filtering]
+nofollow=!https:\/\/maas.io\/docs\/
+checkextern=1
+ignore=
+  https://res\.cloudinary\.com
+  .*&start=
+  /q_auto
+  /fl_sanitize
+  /w_
+  /h_
+  https://assets\.ubuntu\.com
+  https?://.*example\.com
+  https://my\.registry:port
+
+[output]
+status=0
+warnings=0

--- a/scripts/runDocsLinkchecker
+++ b/scripts/runDocsLinkchecker
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if ! ls $HOME/.linkchecker/linkchecker-out.txt; then
+    echo "No linkchecker output found"
+    exit 1
+fi
+
+if grep -q "Error: 4" $HOME/.linkchecker/linkchecker-out.txt; then
+    cat $HOME/.linkchecker/linkchecker-out.txt
+    exit 1
+else
+    echo "No 400 errors were detected"
+    exit 0
+fi


### PR DESCRIPTION
## Done
- Move the linkcheckerrc to a script file
- Add a parse bash script to parse the output from the linkchecker
- Update the docs-link workflow to work with the new scripts

## QA
- An action run looking for 500's which should fail: https://github.com/canonical-web-and-design/maas.io/runs/3832868102?check_suite_focus=true
- An action tun looking for 400's which should pass: https://github.com/canonical-web-and-design/maas.io/runs/3832800272?check_suite_focus=true 
