### PR TITLE
fix: homepage navigation

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -2,7 +2,7 @@
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
-        <a class="p-navigation__link" href="#">
+        <a class="p-navigation__link" href="/">
           <div class="p-navigation__logo-tag">
             <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/0a1e5f5d-Canonical-MAAS-logo-2022.svg" alt="">
           </div>


### PR DESCRIPTION
## Done

fix homepage navigation

## QA

1. Go to the tour page https://maas-io-759.demos.haus/tour
2. Click on the logo
3. You should be taken to the homepage

## Issue / Card

Fixes: #758

## Screenshots

[if relevant, include a screenshot]
