### PR TITLE
refactor: Change Ubuntu Advantage references to Ubuntu Pro

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -660,9 +660,9 @@ document.addEventListener('DOMContentLoaded', function () {
     </div>
     <div class="col-6">
       <div class="col-6">
-        <p>MAAS is freely available, open source software from Canonical. Support and commercial capabilities for MAAS are included with <a href="https://www.ubuntu.com/pricing/infra">Ubuntu Advantage for Infrastructure(UA-I)</a>. This support is charged on a per-machine basis. For example, if Ubuntu Advantage for Infrastructure is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
-        <p>In the case where Ubuntu Advantage for Infrastructure is not purchased for managed machines, then MAAS support can be purchased as a standalone service.</p>
-        <p>To be eligible for standalone support, UA-I is always required for machines hosting MAAS itself.</p>
+        <p>MAAS is freely available, open source software from Canonical. Support and commercial capabilities for MAAS are included with <a href="https://ubuntu.com/pricing/pro">Ubuntu Pro for Infrastructure(UA-I)</a>. This support is charged on a per-machine basis. For example, if Ubuntu Advantage for Infrastructure is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
+        <p>In the case where Ubuntu Pro for Infrastructure is not purchased for managed machines, then MAAS support can be purchased as a standalone service.</p>
+        <p>To be eligible for standalone support, UP-I is always required for machines hosting MAAS itself.</p>
         <p>The pricing for standalone support for machines managed by MAAS is as follows:</p>
       </div>  
     </div>


### PR DESCRIPTION
## Done

- Change Advantage text references to Pro
- Fix URL to new Pro URL

## QA

- Navigate to index
- Ensure there are no remaining references to Ubuntu Advantage