### PR TITLE
fix(workflows): Run Python tests on 20.04 instead of 22.04 / latest

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,7 +68,7 @@ jobs:
         run: yarn lint-python
 
   test-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Done

Changed Python test workflow to run on 20.04

This is necessary due to the following:
https://github.com/actions/runner-images#ongoing-migrations

Our docker image uses Python 3.8, which is standard on 20.04 but on 22.04 (`latest`) 3.10 is standard, which breaks our test workflow.

This probably necessitates updating our docker image to use Python 3.10 and ensuring our code runs as expected on 3.10