### PR TITLE
Fix video scaling on /

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
     <div class="col-5 u-hide--small">
       <div class="u-embedded-media">
         <iframe
+          class="u-embedded-media__element"
           width="441"
           height="247"
           src="https://www.youtube.com/embed/eHfaiKlUYsM?showinfo=0&controls=2&modestbranding=1"
@@ -664,7 +665,7 @@ document.addEventListener('DOMContentLoaded', function () {
         <p>In the case where Ubuntu Advantage for Infrastructure is not purchased for managed machines, then MAAS support can be purchased as a standalone service.</p>
         <p>To be eligible for standalone support, UA-I is always required for machines hosting MAAS itself.</p>
         <p>The pricing for standalone support for machines managed by MAAS is as follows:</p>
-      </div>  
+      </div>
     </div>
   </div>
   <div class="p-strip">


### PR DESCRIPTION
## Done

- Fixes video scaling on `/` but adding 'u-embedded-media__element' class to iframe element

## QA

Go to 
Check that on medium sized screens the videos spans across all available grids

## Issue / Card

https://github.com/canonical/maas.io/issues/774

## Screenshots

![image](https://user-images.githubusercontent.com/58276363/226291706-f7dfed48-2f45-4202-aec8-8730ee7ff217.png)

