### PR TITLE
Update OpenAPI URL with correct location

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -125,7 +125,7 @@ def api():
     # https://docs.google.com/document/d/1vCdC7BV53ncOTpWHd2nX5NbwvUH5fDwy-RQGlWpWhXk/edit
     definition_url = (
         "https://raw.githubusercontent.com"
-        "/maas/maas-openapi-yaml/main/openapi2.yaml"
+        "/maas/maas-openapi-yaml/main/openapi.yaml"
     )
     definition = read_yaml_from_url(definition_url, openapi_session)
     openapi = parse_openapi(definition)


### PR DESCRIPTION
## Done

Changed openapi endpoint to https://raw.githubusercontent.com/maas/maas-openapi-yaml/main/openapi.yaml
