### PR TITLE
Rename UA to Pro

### DIFF
--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -14,8 +14,8 @@
     </div>
     <div class="p-card col-4 u-no-margin--bottom">
       <h3 class="p-card__title">Looking for a little professional support?</h3>
-      <p>If you are a small organisation, you can purchase packs of Ubuntu Advantage in our shop.</p>
-      <p><a href="https://buy.ubuntu.com" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Visit the Ubuntu Advantage shop' });">Visit the Ubuntu Advantage shop</a></p>
+      <p>If you are a small organisation, you can purchase packs of Ubuntu Pro in our shop.</p>
+      <p><a href="https://buy.ubuntu.com" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Visit the Ubuntu Pro shop' });">Visit the Ubuntu Pro shop</a></p>
     </div>
   </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -661,9 +661,9 @@ document.addEventListener('DOMContentLoaded', function () {
     </div>
     <div class="col-6">
       <div class="col-6">
-        <p>MAAS is freely available, open source software from Canonical. Support and commercial capabilities for MAAS are included with <a href="https://www.ubuntu.com/pricing/infra">Ubuntu Advantage for Infrastructure(UA-I)</a>. This support is charged on a per-machine basis. For example, if Ubuntu Advantage for Infrastructure is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
-        <p>In the case where Ubuntu Advantage for Infrastructure is not purchased for managed machines, then MAAS support can be purchased as a standalone service.</p>
-        <p>To be eligible for standalone support, UA-I is always required for machines hosting MAAS itself.</p>
+        <p>MAAS is freely available, open source software from Canonical. Support and commercial capabilities for MAAS are included with <a href="https://www.ubuntu.com/pricing/pro">Ubuntu Pro for Infrastructure</a>. This support is charged on a per-machine basis. For example, if Ubuntu Pro for Infrastructure is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
+        <p>In the case where Ubuntu Pro for Infrastructure is not purchased for managed machines, then MAAS support can be purchased as a standalone service.</p>
+        <p>To be eligible for standalone support, Ubuntu Pro is always required for machines hosting MAAS itself.</p>
         <p>The pricing for standalone support for machines managed by MAAS is as follows:</p>
       </div>
     </div>

--- a/templates/support.html
+++ b/templates/support.html
@@ -37,7 +37,7 @@
       <h2>Bare metal enterprise support</h2>
       <p>MAAS is freely available, open source software from Canonical. However, if you need enterprise support from the people that know MAAS best, then you can get it in one of two ways:</p>
       <ol>
-        <li>Ubuntu Advantage for Infrastructure (UA-I)</li>
+        <li>Ubuntu Pro for Infrastructure</li>
         <li>MAAS Standalone</li>
       </ol>
     </div>
@@ -47,8 +47,8 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-6">
-      <h2>Ubuntu Advantage for Infrastructure</h2>
-      <p>Support and commercial capabilities for MAAS are included with <a href="https://www.ubuntu.com/pricing/infra">Ubuntu Advantage for Infrastructure</a> (UA-I). This support is charged on a per-machine basis. For example, if UA-I is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
+      <h2>Ubuntu Pro for Infrastructure</h2>
+      <p>Support and commercial capabilities for MAAS are included with <a href="https://www.ubuntu.com/pricing/pro">Ubuntu Pro for Infrastructure</a>. This support is charged on a per-machine basis. For example, if Ubuntu Pro is purchased for 100 machines, then MAAS support is also included for those 100 machines.</p>
     </div>
   </div>
 </section>
@@ -57,7 +57,7 @@
   <div class="row">
     <div class="col-8 u-sv3">
       <h2>MAAS Standalone support</h2>
-      <p>In case you don't want support for Ubuntu or other Canonical products on machines that you want to manage with MAAS, then you can buy MAAS Standalone support instead. To be eligible for standalone support, UA-I is always required for the machines hosting MAAS itself. The pricing for standalone support for machines managed by MAAS is as follows:</p>
+      <p>In case you don't want support for Ubuntu or other Canonical products on machines that you want to manage with MAAS, then you can buy MAAS Standalone support instead. To be eligible for standalone support, Ubuntu Pro is always required for the machines hosting MAAS itself. The pricing for standalone support for machines managed by MAAS is as follows:</p>
     </div>
   </div>
   <div class="u-fixed-width">

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -8,7 +8,7 @@
 <section class="p-strip is-deep">
         <div class="row u-equal-height">
             <div class="col-7">
-                <h1>Thanks for contacting us about Ubuntu Advantage</h1>
+                <h1>Thanks for contacting us about Ubuntu Pro</h1>
                 <h2>A member of our team will be in touch shortly.</h2>
                 <p>If you are stuck, help is always at hand.  Reach out to the MAAS community to <a href="http://askubuntu.com">ask a question on askubuntu</a>, <a href="http://www.ubuntu.com/support">join a forum</a> or <a href="http://docs.maas.io">take a look at the documentation</a>.</p>
             </div>

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -175,7 +175,7 @@
                     <li>RHEL</li>
                 </ul>
                 <p>Import, update or sync the images or connect to an onsite mirror to work offline.</p>
-                <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" aria-label="External link to the Ubuntu Advantage page on ubuntu dot com">Ubuntu Advantage</a> licence</small> </p>
+                <p id="image-info"><small>* Images other than Ubuntu and CentOS require an <a href="https://www.ubuntu.com/pro" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });" aria-label="External link to the Ubuntu Pro page on ubuntu dot com">Ubuntu Pro</a> licence</small> </p>
                 <p class="u-sv2"><a href="https://maas.io/docs/images" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' });" aria-label="Link to the install config images page on MAAS documentation">Learn more about images&nbsp;&rsaquo;</a></p>
             </div>
         </div>


### PR DESCRIPTION
## Done
- Rename Ubuntu Advantage to Ubuntu Pro
- Remove `(UA-I)`
- Updated a few links

## QA
- Check the code works

## Issue / Card
Fixes https://github.com/canonical/maas.io/issues/780
