### PR TITLE
Fix cachecontrol filecache dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask_base==1.1.0
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.discourse==5.4.1
-canonicalwebteam.http==1.0.3
+canonicalwebteam.http==1.0.4
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
Update to latest canonicalwebteam.http to fix [the rollout issue with the filelock dependency](https://chat.canonical.com/canonical/pl/an1upu9nktdn5bkw3y845ko9oe).

## QA

Check the demo is running successfully https://maas-io-790.demos.haus/