### PR TITLE
Remove stray `| Snapcraft` copy-pasta from blog template

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block page_title %}{{ article.title.rendered|safe }} | Snapcraft{% endblock %}
+{% block page_title %}{{ article.title.rendered|safe }} | MAAS{% endblock %}
 {% block page_description %}{{ article.excerpt.raw }}{% endblock %}
 {% if article.image and article.image.source_url %}
   {% block meta_image %}{{ article.image.source_url }}{% endblock %}


### PR DESCRIPTION
## Done

Fix blog template to remove `Snapcraft` title addendum

## QA


## Issue / Card

## Screenshots
