### PR TITLE
[redirects] Remove redirect that's handled in Discourse

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1175,7 +1175,6 @@ docs/cli-tag-management: /docs/about-tags-and-annotations
 docs/commission-nodes: /docs/how-to-deploy-machines 
 docs/commissioning-and-hardware-testing-scripts: /docs/commissioning-script-reference  
 docs/commissioning-logs: /docs/commissioning-log-reference 
-docs/commissioning-scripts-reference: /docs/commissioning-script-reference 
 docs/concepts-and-terms: /docs/maas-concepts-and-terms-reference 
 docs/configuration-journey: /docs/how-to-install-maas
 docs/configure-networking: /docs/how-to-manage-networks 


### PR DESCRIPTION
## Done

Removed redirect from `/docs/commissioning-scripts-reference` to `/docs/commissioning-script-reference` (note plural to singular).

The pluralisation style has changed and is now preferred. The doc page in question is titled "Commissioning Scripts Reference" and it would be preferable to have the URL match, but can't without hitting a 404 due to the website redirects intercepting the link from the nav in the Docs and redirecting.

## QA

## Issue / Card

Relates to #795 

## Screenshots

