### PR TITLE
fix: heading bottom margin

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -526,7 +526,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <section class="p-strip--accent is-shallow">
   <div class="row u-equal-height">
     <div class="col-10">
-      <h3 class="p-heading--2 u-no-margin--bottom">Learn how to configure and install MAAS</h3>
+      <h3 class="p-heading--2">Learn how to configure and install MAAS</h3>
       <br class="u-hide--medium u-hide--large" />
     </div>
     <div class="col-2 u-vertically-center">


### PR DESCRIPTION
## Done

fix: heading bottom margin

## QA Steps
Go to the home page
Verify that the updated section has a correct bottom margin

## Screenshots
### Before
<img width="1505" alt="Google Chrome screenshot 000381@2x" src="https://github.com/canonical/maas.io/assets/7452681/de23f24f-7719-45c4-8286-9e69e7c7be6e">
<img width="903" alt="Google Chrome screenshot 000383@2x" src="https://github.com/canonical/maas.io/assets/7452681/94f9cdfd-aa2a-46cd-8148-660b77db3c98">

### After
<img width="1507" alt="Google Chrome screenshot 000379@2x" src="https://github.com/canonical/maas.io/assets/7452681/b2fed52a-beba-4119-b7a8-109c26efad53">
<img width="904" alt="Google Chrome screenshot 000385@2x" src="https://github.com/canonical/maas.io/assets/7452681/42acd19a-3d1b-4d3d-9f0d-bab42565dd7d">


