### PR TITLE
feat: return metadata for `go get`

### DIFF
--- a/templates/gomod.html
+++ b/templates/gomod.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="go-import" content="maas.io/core git https://git.launchpad.net/~maas-committers/maas">
+</head>
+</html>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,6 +26,34 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
 
+    def test_gomod(self):
+        """
+        When given /core.* with go-get=1 query parameter,
+        we should return gomod
+        """
+
+        self.assertEqual(self.client.get("/core?go-get=1").status_code, 200)
+        self.assertEqual(
+            self.client.get("/core/maas?go-get=1").status_code, 200
+        )
+        self.assertEqual(
+            self.client.get("/core/maas/src?go-get=1").status_code, 200
+        )
+
+    def test_gomod_not_found(self):
+        """
+        When given /core.* without go-get=1 query parameter,
+        we should return a 404 status code
+        """
+
+        self.assertEqual(self.client.get("/core").status_code, 404)
+        self.assertEqual(self.client.get("/core/maas").status_code, 404)
+        self.assertEqual(self.client.get("/core/maas/src").status_code, 404)
+        self.assertEqual(self.client.get("/core/maas?go-get").status_code, 404)
+        self.assertEqual(
+            self.client.get("/core/maas/src?go-get=0").status_code, 404
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -127,7 +127,7 @@ def gomod(subpath):
     if flask.request.query_string == b"go-get=1":
         return flask.render_template("gomod.html"), 200
 
-    return flask.abort(404)
+    flask.abort(404)
 
 
 init_blog(app, "/blog")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -115,5 +115,20 @@ def api():
     )
 
 
+@app.route("/core", defaults={"subpath": None})
+@app.route("/core/<path:subpath>")
+def gomod(subpath):
+    """
+    Return metadata for Go package manager
+    That allows to do things like `go get maas.io/core/src/maasagent`
+    by using Git repository at https://code.launchpad.net/maas
+    """
+
+    if flask.request.query_string == b"go-get=1":
+        return flask.render_template("gomod.html"), 200
+
+    return flask.abort(404)
+
+
 init_blog(app, "/blog")
 init_tutorials(app, "/tutorials", session)


### PR DESCRIPTION
## Done

Add special route `/core/<path:subpath>` and check for `go-get=1` query param

Instead of getting MAAS Go modules using `go get git.launchpad.net/~maas-committers/maas` and then import things like:
```go
git.launchpad.net/~maas-committers/maas/src/maasagent/pkg/workflow/codec
```

Return special `meta` that will help Go tools to discover correct VCS.
That will allow developers to get modules with `go get maas.io/core/maas` and then import as:
```go
maas.io/core/src/maasagent/pkg/workflow/codec
```