### PR TITLE
fix(api): Fix openapi documentation display script

### DIFF
--- a/templates/docs/api.html
+++ b/templates/docs/api.html
@@ -156,12 +156,10 @@
               {%endfor%}
             {%endif%}
             {%if "requestBody" in item[endpoint][method]%}
-              {%if "parameters" not in item[endpoint] and "parameters" not in item[endpoint][method]%}
-                <p><strong>Parameters</strong></p>
-                <hr />
-              {%endif%}
-              {%for property in item[endpoint][method]["requestBody"]["content"]["application/json"]["schema"]["properties"]%}
-                <p><md-block><code>{{property}}</code> (<em>{{item[endpoint][method]["requestBody"]["content"]["application/json"]["schema"]["properties"][property]["type"]}}</em>): {%if property in item[endpoint][method]["requestBody"]["content"]["application/json"]["schema"]["required"]%}Required{%else%}Optional{%endif%}. {{item[endpoint][method]["requestBody"]["content"]["application/json"]["schema"]["properties"][property]["description"].replace(" -", "\n -")}}</md-block></p>
+              <p><strong>Request body (multipart/form-data)</strong></p>
+              <hr />
+              {%for property in item[endpoint][method]["requestBody"]["content"]["multipart/form-data"]["schema"]["properties"]%}
+                <p><md-block><code>{{property}}</code> (<em>{{item[endpoint][method]["requestBody"]["content"]["multipart/form-data"]["schema"]["properties"][property]["type"]}}</em>): {%if property in item[endpoint][method]["requestBody"]["content"]["multipart/form-data"]["schema"]["required"]%}Required{%else%}Optional{%endif%}. {{item[endpoint][method]["requestBody"]["content"]["multipart/form-data"]["schema"]["properties"][property]["description"].replace(" -", "\n -")}}</md-block></p>
               {%endfor%}
             {%endif%}
             <p><strong>Responses</strong></p>


### PR DESCRIPTION
## Done

- Fixed OpenAPI display script by replacing "application/json" check in request body with "multipart/form-data"

## QA

- Go to /docs/api
- Open a few endpoints that have methods with request bodies
- Ensure there are no duplicate parameters and that the properties are being displayed correctly

A few to check:
- `PUT /MAAS/api/2.0/boot-sources/{boot_source_id}/selections/{id}`
- `DELETE /MAAS/api/2.0/devices/{system_id}/`
- `DELETE /MAAS/api/2.0/devices/{system_id}/`
- `PUT /MAAS/api/2.0/dnsresourcerecords/{id}/`

## Screenshots

### Before
![image](https://github.com/canonical/maas.io/assets/35104482/1cb15f41-dd1e-4b97-9abb-f328e28e85ec)

### After
![image](https://github.com/canonical/maas.io/assets/35104482/00d32317-da37-4f05-9b88-66a1abf02fda)
