### PR TITLE
fix(api): Render parameter descriptions using markdown

### DIFF
--- a/templates/docs/api.html
+++ b/templates/docs/api.html
@@ -146,7 +146,7 @@
               <p><strong>Parameters</strong></p>
               <hr />
               {%for param in item[endpoint][method]["parameters"]%}
-                <p><code>&#123;{{param["name"]}}&#125;</code> (<em>{{param["schema"]["type"]}}</em>): {%if param["required"] == True%} Required. {%else%} Optional.{%endif%} {{param["description"]}}</p>
+                <p><code>&#123;{{param["name"]}}&#125;</code> (<em>{{param["schema"]["type"]}}</em>): {%if param["required"] == True%} Required. {%else%} Optional.{%endif%} <md-block>{{param["description"]}}</md-block></p>
               {%endfor%}
             {%elif "parameters" in item[endpoint]%}
               <p><strong>Parameters</strong></p>


### PR DESCRIPTION
## Done

- Added markdown support to endpoint parameters (thanks @SK1Y101 for the backend fix!)

## QA

- Go to /docs/api
- Scroll down to "MAAS server"
- Open "GET"
- Ensure `name` parameter options are displayed correctly
- Close "GET" and open "POST"
- Ensure `name` request body options are displayed correctly

## Issue / Card

Fixes #806 

## Screenshots

### Before
![image](https://github.com/canonical/maas.io/assets/35104482/c32ab91f-29fa-4579-b0b9-1dd612e52027)

### After
![image](https://github.com/canonical/maas.io/assets/35104482/51960c0d-bd56-430b-8002-700a2bc48a69)

