### PR TITLE
Fix table of contents position in documentation layout

### DIFF
--- a/templates/docs/api.html
+++ b/templates/docs/api.html
@@ -4,11 +4,14 @@
 {% block twitter_title %}API{% endblock %}
 {% block og_title %}API{% endblock %}
 
+{% block title %}
+  <h1 id="maas-api">MAAS API</h1>
+{% endblock %}
+
 {% block content %}
 <div class="l-docs__main u-text-max-width" id="content-section">
   <main class="u-fixed-width">
     <div class="p-strip u-no-padding--top">
-      <h1 id="maas-api">MAAS API</h1>
       <p>Restful MAAS API.</p>
       <p>This is the documentation for the API that lets you control and query MAAS. The API is "Restful", which means that you access it through normal HTTP requests.</p>
       <h2 id="api-versions">API versions</h2>

--- a/templates/docs/base_docs.html
+++ b/templates/docs/base_docs.html
@@ -110,6 +110,14 @@
     </div>
   </div>
 
+  <div class="l-docs__title">
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        {% block title %}{% endblock %}
+      </div>
+    </div>
+  </div>
+
   {% if document is defined and document.headings_map is defined and document.headings_map|length > 0 %}
 
   <div class="l-docs__meta">

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -5,28 +5,27 @@
 {% block twitter_title %}{{ document.title }}{% endblock twitter_title %}
 {% block og_title %}{{ document.title }}{% endblock og_title %}
 
+{% block title %}
+  <h1>{{ document.title }}</h1>
+{% endblock %}
+
 {% block content %}
 
 <div class="l-docs__main u-text-max-width">
   <main class="u-fixed-width">
-    <div class="p-strip is-shallow u-no-padding--top">
+    <div class="p-section--shallow">
       <div class="u-fixed-width">
-        <h1 class="l-docs-title__heading u-no-margin--bottom">{{ document.title }}</h1>
-      </div>
-    </div>
-    <div class="p-strip is-shallow">
-      <div class="l-docs-row row">
         {{ document.body_html | safe }}
       </div>
     </div>
-    <div class="p-strip is-shallow u-no-padding--bottom">
-      <div class="l-docs-row row">
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
         <hr />
         <p><i>Last updated {{ document.updated }}.</i></p>
       </div>
     </div>
-    <div class="p-strip is-shallow u-no-padding--bottom u-sticky--bottom">
-      <div class="l-docs-row row">
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
         <div class="p-notification--information">
           <div class="p-notification__content">
             <p class="p-notification__message">


### PR DESCRIPTION
## Done

Separates the title from content of the docs to correctly position table of contents between title and the content in the documentation layout.

## QA

- Run the demo
- Go to /docs
- Make the screen smaller than 1300px, make sure table of contents is below the title and above rest of the content, not on top of everything

## Screenshots

Before:

<img width="1277" alt="image" src="https://github.com/canonical/maas.io/assets/83575/f379e9aa-f032-4e63-9e00-6156dd6ee149">

After (expected):

<img width="1277" alt="image" src="https://github.com/canonical/maas.io/assets/83575/d7435d93-92a5-4951-907d-4eb154bba865">


