### PR TITLE
move openapi link to correct repo

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -101,7 +101,7 @@ def api():
     # https://docs.google.com/document/d/1vCdC7BV53ncOTpWHd2nX5NbwvUH5fDwy-RQGlWpWhXk/edit
     definition_url = (
         "https://raw.githubusercontent.com"
-        "/maas/maas-openapi-yaml/main/openapi.yaml"
+        "/canonical/maas-openapi-yaml/main/openapi.yaml"
     )
     definition = read_yaml_from_url(definition_url, session=openapi_session)
     openapi = parse_openapi(definition)


### PR DESCRIPTION
## Done

openapi source pointed to a MAAS org repo, which has since been moved to the canonical org

## QA

MAAS api docs https://maas-io-789.demos.haus/docs/api should correctly populate
