### PR TITLE
chore: Update canonicalwebteam.discourse to 5.5.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Dotrun
-        uses: canonical/install-dotrun@main
+      - name: Install dotrun
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Install dependencies
         run: |
@@ -59,8 +59,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
-
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
+      
       - name: Install dependencies
         run: |
           sudo chmod -R 777 .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask_base==1.1.0
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.discourse==5.4.3
+canonicalwebteam.discourse==5.5.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.search==1.3.0


### PR DESCRIPTION
## Done

- Update canonicalwebteam.discourse to 5.5.0. This adds functionality to remove trailing numbers from heading anchors, as by default they do not behave as expected

## QA

- Open https://maas-io-820.demos.haus/docs
- Inspect a heading (h2 and down) and see the anchor link within it doesn't have trailing number
