### PR TITLE
feat: Include h3 in table of contents WD-17309 MAASENG-4219

### DIFF
--- a/templates/docs/base_docs.html
+++ b/templates/docs/base_docs.html
@@ -128,7 +128,14 @@
           <nav class="p-table-of-contents__nav" aria-label="Table of contents">
             <ul class="p-table-of-contents__list">
               {% for heading in document.headings_map %}
-              <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+                <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a></li>
+                {% if heading.children %}
+                  <ul class="p-table-of-contents__list">
+                    {% for child in heading.children %}
+                      <li class="p-table-of-contents__item"><a href="#{{ child.heading_slug }}" class="p-table-of-contents__link">{{ child.heading_text }}</a></li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
               {% endfor %}
             </ul>
           </nav>


### PR DESCRIPTION
## Done

- Included H3 headings in the generated table of contents for each page of docs

[List of work items including drive-bys]

## QA

- Go to /docs/reference-installation-requirements
- Ensure H3 headings show in the table of contents at the top:
  - "Getting information using psql"
  - "Getting information via configuration file"
  - "Increasing maximum connections"
  - "Symptoms of an issue"

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Resolves [MAASENG-4219](https://warthogs.atlassian.net/browse/MAASENG-4219)
Resolves [WD-17309](https://warthogs.atlassian.net/browse/WD-17309)

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/9ef8e007-325d-4e41-9815-c99138c1b9a5)

### After
![image](https://github.com/user-attachments/assets/480cadd9-6ace-4ba4-a709-305517e21e2e)

[if relevant, include a screenshot]


[MAASENG-4219]: https://warthogs.atlassian.net/browse/MAASENG-4219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-17309]: https://warthogs.atlassian.net/browse/WD-17309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ