### PR TITLE
chore: add redirect for deprecation notice MD5

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1363,3 +1363,4 @@ deprecations/MD1: https://discourse.maas.io/t/1415
 deprecations/MD2: https://discourse.maas.io/t/4236
 deprecations/MD3: https://discourse.maas.io/t/6216
 deprecations/MD4: https://discourse.maas.io/t/7440
+deprecations/MD5: /docs/how-to-upgrade-from-postgresql-v14-to-v16


### PR DESCRIPTION
Add a redirection for the MAAS deprecation notice MD5
